### PR TITLE
feat: wasm returns js object

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, TJAParser};
+use crate::TJAParser;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,13 +1,13 @@
-use crate::TJAParser;
+use crate::{types::*, TJAParser};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn parse_tja(content: &str) -> Result<String, JsValue> {
+pub fn parse_tja(content: &str) -> Result<JsValue, JsValue> {
     let mut parser = TJAParser::new();
     parser
         .parse_str(content)
         .map_err(|e| JsValue::from_str(&e))?;
 
     let parsed = parser.get_parsed_tja();
-    serde_json::to_string(&parsed).map_err(|e| JsValue::from_str(&e.to_string()))
+    serde_wasm_bindgen::to_value(&parsed).map_err(|e| JsValue::from_str(&e.to_string()))
 }

--- a/tja.d.ts
+++ b/tja.d.ts
@@ -1,0 +1,33 @@
+export function parse_tja(content: string): Promise<ParsedTJA>;
+
+export interface ParsedTJA {
+    metadata: Record<string ,string>;
+    charts: Chart[];
+}
+
+export interface Chart {
+    player: number;
+    course?: "Easy" | "Normal" | "Hard" | "Oni" | "Ura";
+    level?: number;
+    balloons: number[];
+    headers: Record<string ,string>;
+    segments: Segment[];
+}
+
+export interface Segment {
+    measure_num: number;
+    measure_den: number;
+    barline: boolean;
+    branch?: string;
+    branch_condition?: string;
+    notes: Note[];
+}
+
+export interface Note {
+    note_type: "Empty" | "Don" | "Ka" | "DonBig" | "KaBig" | "Roll" | "RollBig" | "Balloon" | "EndOf" | "BalloonAlt";
+    timestamp: number;
+    scroll: number;
+    delay: number;
+    bpm: number;
+    gogo: boolean;
+}


### PR DESCRIPTION
This pull request includes changes to the `src/wasm.rs` file to improve the handling of parsed TJA data and streamline the code. The most important changes are:

Improvements to data handling:

* Modified the `parse_tja` function to return a `JsValue` instead of a `String`, ensuring better compatibility with WebAssembly.
* Changed the serialization method from `serde_json::to_string` to `serde_wasm_bindgen::to_value` for converting parsed TJA data to a `JsValue`, which is optimized for WebAssembly environments.

Codebase simplification:

* Updated the import statement to use a more concise format by combining multiple imports from the same crate into a single line.