### PR TITLE
feat: different paring mode

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Benchmark Page
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    benchmark:
+        name: Build Benchmark Page
+        runs-on: macos-latest
+        permissions:
+            pages: write
+            id-token: write
+            contents: read
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install Rust
+              uses: actions-rs/toolchain@v1
+              with:
+                  toolchain: stable
+
+            - name: Run benchmark
+              run: cargo bench
+
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: "target/criterion"
+
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TJA file parser written in Rust, working in Rust, Python, and WebAssembly.
 
+It's fast! [See the benchmark](https://jacoblincool.github.io/tja-rs/report/)
+
 ## Building
 
 ### Rust

--- a/benches/parser_benchmark.rs
+++ b/benches/parser_benchmark.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fs;
 use std::path::Path;
-use tja::TJAParser;
+use tja::{ParsingMode, TJAParser};
 
 fn parse_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("TJA Parser");
@@ -24,14 +24,23 @@ fn parse_benchmark(c: &mut Criterion) {
         })
         .collect();
 
-    // Benchmark each file
+    // Define parsing modes to benchmark
+    let modes = [
+        (ParsingMode::MetadataOnly, "metadata_only"),
+        (ParsingMode::MetadataAndHeader, "metadata_and_header"),
+        (ParsingMode::Full, "full"),
+    ];
+
+    // Benchmark each file with each parsing mode
     for (filename, content) in tja_files {
-        group.bench_function(format!("parse {}", filename), |b| {
-            b.iter(|| {
-                let mut parser = TJAParser::new();
-                parser.parse_str(black_box(&content)).unwrap();
+        for (mode, mode_name) in &modes {
+            group.bench_function(format!("{} - {}", mode_name, filename), |b| {
+                b.iter(|| {
+                    let mut parser = TJAParser::with_mode(mode.clone());
+                    parser.parse_str(black_box(&content)).unwrap();
+                });
             });
-        });
+        }
     }
 
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,4 +54,28 @@ mod tests {
             insta::assert_json_snapshot!("mint_tears", parsed_tja);
         });
     }
+
+    #[test]
+    fn test_parse_supernova_metadata_only() {
+        let content = fs::read_to_string("data/SUPERNOVA.tja").unwrap();
+        let mut parser = TJAParser::with_mode(ParsingMode::MetadataOnly);
+        parser.parse_str(&content).unwrap();
+        let parsed_tja = parser.get_parsed_tja();
+
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_json_snapshot!("supernova_metadata_only", parsed_tja);
+        });
+    }
+
+    #[test]
+    fn test_parse_supernova_metadata_and_header() {
+        let content = fs::read_to_string("data/SUPERNOVA.tja").unwrap();
+        let mut parser = TJAParser::with_mode(ParsingMode::MetadataAndHeader);
+        parser.parse_str(&content).unwrap();
+        let parsed_tja = parser.get_parsed_tja();
+
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_json_snapshot!("supernova_metadata_and_header", parsed_tja);
+        });
+    }
 }

--- a/src/snapshots/tja__tests__supernova_metadata_and_header.snap
+++ b/src/snapshots/tja__tests__supernova_metadata_and_header.snap
@@ -1,0 +1,132 @@
+---
+source: src/lib.rs
+expression: parsed_tja
+snapshot_kind: text
+---
+{
+  "metadata": {
+    "bpm": 211.99990844726563,
+    "offset": -1.1999999641890422,
+    "demostart": 116.952,
+    "songvol": 100,
+    "sevol": 100,
+    "raw": {
+      "BPM": "211.999908447265625",
+      "DEMOSTART": "116.952",
+      "OFFSET": "-1.19999996418904221875",
+      "SCOREMODE": "2",
+      "SEVOL": "100",
+      "SONGVOL": "100",
+      "SUBTITLE": "--USAO",
+      "TITLE": "SUPERNOVA",
+      "WAVE": "SUPERNOVA.ogg"
+    }
+  },
+  "charts": [
+    {
+      "player": 0,
+      "course": "Ura",
+      "level": 10,
+      "balloons": [
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        3,
+        39,
+        3,
+        3
+      ],
+      "headers": {
+        "BALLOON": "3,3,3,3,3,3,3,39,3,3",
+        "COURSE": "Edit",
+        "LEVEL": "10",
+        "SCOREDIFF": "0",
+        "SCOREINIT": "910"
+      },
+      "segments": []
+    },
+    {
+      "player": 0,
+      "course": "Oni",
+      "level": 10,
+      "balloons": [
+        29,
+        2
+      ],
+      "headers": {
+        "BALLOON": "29,2",
+        "COURSE": "Oni",
+        "LEVEL": "10",
+        "SCOREDIFF": "0",
+        "SCOREINIT": "1070"
+      },
+      "segments": []
+    },
+    {
+      "player": 0,
+      "course": "Hard",
+      "level": 8,
+      "balloons": [
+        8,
+        30,
+        19,
+        30,
+        5,
+        8
+      ],
+      "headers": {
+        "BALLOON": "8,30,19,30,5,8",
+        "COURSE": "Hard",
+        "LEVEL": "8",
+        "SCOREDIFF": "0",
+        "SCOREINIT": "1980"
+      },
+      "segments": []
+    },
+    {
+      "player": 0,
+      "course": "Normal",
+      "level": 7,
+      "balloons": [
+        5,
+        18,
+        11,
+        18,
+        5,
+        6
+      ],
+      "headers": {
+        "BALLOON": "5,18,11,18,5,6",
+        "COURSE": "Normal",
+        "LEVEL": "7",
+        "SCOREDIFF": "0",
+        "SCOREINIT": "2440"
+      },
+      "segments": []
+    },
+    {
+      "player": 0,
+      "course": "Easy",
+      "level": 5,
+      "balloons": [
+        4,
+        15,
+        9,
+        15,
+        4,
+        5
+      ],
+      "headers": {
+        "BALLOON": "4,15,9,15,4,5",
+        "COURSE": "Easy",
+        "LEVEL": "5",
+        "SCOREDIFF": "0",
+        "SCOREINIT": "3780"
+      },
+      "segments": []
+    }
+  ]
+}

--- a/src/snapshots/tja__tests__supernova_metadata_only.snap
+++ b/src/snapshots/tja__tests__supernova_metadata_only.snap
@@ -1,0 +1,26 @@
+---
+source: src/lib.rs
+expression: parsed_tja
+snapshot_kind: text
+---
+{
+  "metadata": {
+    "bpm": 211.99990844726563,
+    "offset": -1.1999999641890422,
+    "demostart": 116.952,
+    "songvol": 100,
+    "sevol": 100,
+    "raw": {
+      "BPM": "211.999908447265625",
+      "DEMOSTART": "116.952",
+      "OFFSET": "-1.19999996418904221875",
+      "SCOREMODE": "2",
+      "SEVOL": "100",
+      "SONGVOL": "100",
+      "SUBTITLE": "--USAO",
+      "TITLE": "SUPERNOVA",
+      "WAVE": "SUPERNOVA.ogg"
+    }
+  },
+  "charts": []
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,9 +1,26 @@
-use crate::TJAParser;
+use crate::{ParsingMode, TJAParser};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn parse_tja(content: &str) -> Result<JsValue, JsValue> {
-    let mut parser = TJAParser::new();
+pub enum WasmParsingMode {
+    MetadataOnly,
+    MetadataAndHeader,
+    Full,
+}
+
+impl From<WasmParsingMode> for ParsingMode {
+    fn from(mode: WasmParsingMode) -> Self {
+        match mode {
+            WasmParsingMode::MetadataOnly => ParsingMode::MetadataOnly,
+            WasmParsingMode::MetadataAndHeader => ParsingMode::MetadataAndHeader,
+            WasmParsingMode::Full => ParsingMode::Full,
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn parse_tja(content: &str, mode: Option<WasmParsingMode>) -> Result<JsValue, JsValue> {
+    let mut parser = TJAParser::with_mode(mode.unwrap_or(WasmParsingMode::Full).into());
     parser
         .parse_str(content)
         .map_err(|e| JsValue::from_str(&e))?;

--- a/tja.d.ts
+++ b/tja.d.ts
@@ -1,7 +1,13 @@
-export function parse_tja(content: string): Promise<ParsedTJA>;
+export function parse_tja(content: string, mode?: WasmParsingMode): Promise<ParsedTJA>;
+
+export enum WasmParsingMode {
+    MetadataOnly = 0,
+    MetadataAndHeader = 1,
+    Full = 2,
+}
 
 export interface ParsedTJA {
-    metadata: Record<string ,string>;
+    metadata: Record<string, string>;
     charts: Chart[];
 }
 
@@ -10,7 +16,7 @@ export interface Chart {
     course?: "Easy" | "Normal" | "Hard" | "Oni" | "Ura";
     level?: number;
     balloons: number[];
-    headers: Record<string ,string>;
+    headers: Record<string, string>;
     segments: Segment[];
 }
 

--- a/tja.pyi
+++ b/tja.pyi
@@ -1,4 +1,10 @@
+from enum import Enum
 from typing import Dict, List, Optional
+
+class ParsingMode(Enum):
+    MetadataOnly = "MetadataOnly"
+    MetadataAndHeader = "MetadataAndHeader"
+    Full = "Full"
 
 class PyNote:
     note_type: str
@@ -28,4 +34,4 @@ class PyParsedTJA:
     metadata: Dict[str, str]
     charts: List[PyChart]
 
-def parse_tja(content: str) -> PyParsedTJA: ... 
+def parse_tja(content: str, mode: ParsingMode = ParsingMode.Full) -> PyParsedTJA: ... 


### PR DESCRIPTION
This pull request includes several changes to introduce a new `ParsingMode` feature, update benchmarks, and improve the testing and deployment processes. The most important changes include adding the `ParsingMode` enum to control the level of parsing, updating the benchmark and test files to use this new feature, and configuring a GitHub Actions workflow to build and deploy benchmark pages.

### New ParsingMode Feature:

* Added `ParsingMode` enum with variants `MetadataOnly`, `MetadataAndHeader`, and `Full` to control the level of parsing in `TJAParser`. (`src/parser.rs`)
* Implemented the `with_mode` method in `TJAParser` to initialize the parser with a specific `ParsingMode`. (`src/parser.rs`)
* Updated the `parse_str` method to respect the `ParsingMode` and handle parsing accordingly. (`src/parser.rs`) [[1]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL144-R169) [[2]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fR180-L163) [[3]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL172) [[4]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fR198-L186)

### Benchmark and Testing Updates:

* Modified the benchmark file to include different parsing modes in the benchmark tests. (`benches/parser_benchmark.rs`)
* Added new tests to verify the parsing behavior for different `ParsingMode` settings. (`src/lib.rs`)

### Deployment and Documentation:

* Configured a GitHub Actions workflow to build and deploy benchmark pages. (`.github/workflows/pages.yml`)
* Updated the `README.md` to include a link to the benchmark results. (`README.md`)

### Language Bindings:

* Extended Python and WebAssembly bindings to support the new `ParsingMode` feature. (`src/python.rs`, `src/wasm.rs`, `tja.pyi`) [[1]](diffhunk://#diff-e3ae5f2bc0fa3be739d14196e86f9f0aa23ca94aaab674cec6f53bb1bb21937aL1-R1) [[2]](diffhunk://#diff-6d7bc9e99526e7f06b818a6103bd30aaa067263cc8e34a14197e1a3bcf2dd4dbL1-R23) [[3]](diffhunk://#diff-5e87f2030b3106d38f76e574de0ac7dff0ab9884e74fcc8d53040b5e5350f8e6R1-R8)

These changes enhance the flexibility of the parser, improve performance testing, and streamline the deployment of benchmark results.