### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,9 +111,9 @@ jobs:
         strategy:
             matrix:
                 platform:
-                    - runner: macos-13
+                    - runner: macos-15-intel
                       target: x86_64
-                    - runner: macos-14
+                    - runner: macos-26
                       target: aarch64
         steps:
             - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ name = "profile"
 path = "src/bin/profile.rs"
 bench = false
 
+[[bin]]
+name = "analyze"
+path = "src/bin/analyze.rs"
+bench = false
+
 [lib]
 name = "tja"
 crate-type = ["cdylib", "rlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tja"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 description = "TJA file parser written in Rust, working in Rust, Python, and WebAssembly."
 license = "MIT"


### PR DESCRIPTION
This pull request updates the CI workflow to use newer macOS runners and bumps the crate version to reflect recent changes.

Platform and CI updates:

* Updated the GitHub Actions CI workflow in `.github/workflows/CI.yml` to use `macos-15-intel` for `x86_64` builds and `macos-26` for `aarch64` builds, replacing the older `macos-13` and `macos-14` runners.

Versioning:

* Bumped the crate version in `Cargo.toml` from `0.4.1` to `0.5.0` to indicate a new release with potentially breaking changes or significant updates.